### PR TITLE
meson: Allow turning of C language bindings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0
+# SPDX-License-Identifier : Apache-2.0 OR GPL-2.0
 # Copyright © 2022-2024 Intel Corporation
 
 project(
@@ -41,29 +41,35 @@ dep_rpm_ver_cpp = declare_dependency(
 
 meson.override_dependency('rpm-version-c++', dep_rpm_ver_cpp)
 
-lib_c = library(
-  'rpm-version',
-  'src/capi.cpp',
-  link_with : lib_priv,
-  include_directories : inc,
-  install : true,
-  version : so_version,
-)
+if get_option('c-bindings')
+  lib_c = library(
+    'rpm-version',
+    'src/capi.cpp',
+    link_with : lib_priv,
+    include_directories : inc,
+    install : true,
+    version : so_version,
+  )
 
-pkg.generate(
-  lib_c,
-  name : 'rpm-version-c',
-)
+  pkg.generate(
+    lib_c,
+    name : 'rpm-version-c',
+  )
 
-dep_rpm_ver_c = declare_dependency(
-  link_with : lib_c,
-  include_directories : inc,
-)
+  dep_rpm_ver_c = declare_dependency(
+    link_with : lib_c,
+    include_directories : inc,
+  )
 
-meson.override_dependency('rpm-version-c', dep_rpm_ver_c)
+  meson.override_dependency('rpm-version-c', dep_rpm_ver_c)
+
+  install_headers(
+    'include/rpm-version/version.h',
+    subdir : 'rpm-version',
+  )
+endif
 
 install_headers(
-  'include/rpm-version/version.h',
   'include/rpm-version/version.hpp',
   subdir : 'rpm-version',
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,3 +6,9 @@ option(
   type : 'feature',
   description : 'Whether to enable tests or not',
 )
+option(
+  'c-bindings',
+  type : 'boolean',
+  value : true,
+  description : 'whether to build and install C bindings.',
+)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -21,38 +21,40 @@ test(
   )
 )
 
-enable_c_api_test = not get_option('tests').disabled()
-c_api_link_language = 'c'
-if get_option('default_library') == 'static'
-  # If we've statically linked then we have to use the C++ linker :/
-  c_api_link_language = 'cpp'
-else
-  enable_c_api_test = add_languages('c', required : false, native : false)
-endif
+if get_option('c-bindings')
+  enable_c_api_test = true
+  c_api_link_language = 'c'
+  if get_option('default_library') == 'static'
+    # If we've statically linked then we have to use the C++ linker :/
+    c_api_link_language = 'cpp'
+  else
+    enable_c_api_test = add_languages('c', required : false, native : false)
+  endif
 
-if enable_c_api_test
-  if add_languages('c', required : false, native : false)
-    c_api = executable(
-      'c_api_test',
-      'c_api_test.c',
-      link_language : c_api_link_language,
-      dependencies : dep_rpm_ver_c,
-    )
-
-    cases = [
-      ['4', '<', '2', '1'],
-      ['1', '<', '2', '0'],
-      ['4', '>', '2', '0'],
-      ['1', '>', '2', '1'],
-    ]
-
-    foreach case : cases
-      test(
-        '@0@@1@@2@ is @3@'.format(case[0], case[1], case[2], case[3] == '0' ? 'true' : 'false'),
-        c_api,
-        args : case,
-        suite : 'C API'
+  if enable_c_api_test
+    if add_languages('c', required : false, native : false)
+      c_api = executable(
+        'c_api_test',
+        'c_api_test.c',
+        link_language : c_api_link_language,
+        dependencies : dep_rpm_ver_c,
       )
-    endforeach
+
+      cases = [
+        ['4', '<', '2', '1'],
+        ['1', '<', '2', '0'],
+        ['4', '>', '2', '0'],
+        ['1', '>', '2', '1'],
+      ]
+
+      foreach case : cases
+        test(
+          '@0@@1@@2@ is @3@'.format(case[0], case[1], case[2], case[3] == '0' ? 'true' : 'false'),
+          c_api,
+          args : case,
+          suite : 'C API'
+        )
+      endforeach
+    endif
   endif
 endif


### PR DESCRIPTION
Especially when used as a subproject it's possible that a user wouldn't want to build the C bindings if they're not using them.